### PR TITLE
Implement add/delete payment types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Displays the 20 latest products in the Bangazon warehouse!
 #### Prodcuts
 + In the browser, proceeding to ```http://localhost:8080/products/:id```, where :id is an integer, will display a products detail page for an individual product.
 #### Account
++ In the browser, proceeding to ```http://localhost:8080/account```, after being logged in, will display users' payment types.  User can add or delete their payment types on this page.
 
 #### Inventory `/inventory/`
 Leads to the current user's inventory of products they are selling.  Can only be accessed by a logged in user.

--- a/client/js/account.js
+++ b/client/js/account.js
@@ -8,3 +8,22 @@ document.getElementById("editAccount").addEventListener('click', () => {
 document.getElementById("addPaymentType").addEventListener('click', () => {
   location.href = `${location.origin}/account/addPaymentType`;
 });
+
+document.querySelectorAll(".deletePaymentType").forEach((button) => {
+  button.addEventListener('click', (event) => {
+    console.log('event.target.ids', event.target.id);
+    deletePaymentType(event.target.id);
+  });
+});
+
+const deletePaymentType = (id) => {
+  fetch(`${location.origin}/account/deletePaymentType`, {
+    method: 'POST',
+    body: JSON.stringify({
+      paymentTypeId: id,
+    }),
+    headers: new Headers({
+      'Content-Type': 'application/json'
+    })
+  });
+};

--- a/client/js/account.js
+++ b/client/js/account.js
@@ -4,3 +4,7 @@ document.getElementById("editAccount").addEventListener('click', () => {
   location.href = `${location.origin}/account/edit`;
 });
 
+
+document.getElementById("addPaymentType").addEventListener('click', () => {
+  location.href = `${location.origin}/account/addPaymentType`;
+});

--- a/client/js/account.js
+++ b/client/js/account.js
@@ -11,19 +11,26 @@ document.getElementById("addPaymentType").addEventListener('click', () => {
 
 document.querySelectorAll(".deletePaymentType").forEach((button) => {
   button.addEventListener('click', (event) => {
-    console.log('event.target.ids', event.target.id);
     deletePaymentType(event.target.id);
   });
 });
 
 const deletePaymentType = (id) => {
   fetch(`${location.origin}/account/deletePaymentType`, {
-    method: 'POST',
+    method: 'DELETE',
     body: JSON.stringify({
       paymentTypeId: id,
     }),
     headers: new Headers({
-      'Content-Type': 'application/json'
-    })
-  });
+      'Content-Type': 'application/json',
+    }),
+    credentials: 'include',
+  })
+    .then(() => {
+      console.log('redirect');
+    window.location.href = `${location.origin}/account`;
+  })
+    .catch((error) => {
+      console.log(error);
+    });
 };

--- a/controllers/accountCtrl.js
+++ b/controllers/accountCtrl.js
@@ -12,7 +12,15 @@ module.exports.updateAccount = (req, res, next) => {
 }
 
 module.exports.renderAccount = (req, res, next) => {
-  res.render("account", req.user);
+  const { PaymentType } = req.app.get('models');
+  PaymentType.findAll({
+    where: { user_id: req.user.id },
+  }).then(paymentTypes => {
+    res.render("account", {
+      ...req.user,
+      paymentTypes,
+    });
+  });
 }
 
 module.exports.renderAccountEdit = (req, res, next) => {
@@ -29,7 +37,7 @@ module.exports.updatePaymentType = (req, res, next) => {
   const userId = req.user.id;
   const { PaymentType } = req.app.get('models');
 
-  if(provider && accountNumber && userId){
+  if (provider && accountNumber && userId) {
     PaymentType.create({
       user_id: userId,
       provider,
@@ -40,3 +48,16 @@ module.exports.updatePaymentType = (req, res, next) => {
     });
   }
 }
+
+module.exports.deletePaymentType = (req, res, next) => {
+  const paymentTypeId = +req.body.paymentTypeId;
+  const { PaymentType } = req.app.get('models');
+  
+  PaymentType.destroy({
+    where: {
+      id: paymentTypeId,
+    },
+  }).then(() => {
+    res.redirect('/account');
+  });
+};

--- a/controllers/accountCtrl.js
+++ b/controllers/accountCtrl.js
@@ -15,7 +15,7 @@ module.exports.renderAccount = (req, res, next) => {
   const { PaymentType } = req.app.get('models');
 
   PaymentType.findAll({
-    where: { user_id: req.user.id },
+    where: { user_id: req.user.id, active: 't', },
   }).then(paymentTypes => {
     res.render("account", {
       ...req.user,
@@ -54,11 +54,14 @@ module.exports.deletePaymentType = (req, res, next) => {
   const paymentTypeId = +req.body.paymentTypeId;
   const { PaymentType } = req.app.get('models');
 
-  PaymentType.destroy({
-    where: {
-      id: paymentTypeId,
-    },
-  }).then(() => {
+  PaymentType.update(
+    { active: 'f' },
+    {
+      where: {
+        id: paymentTypeId
+      }
+    }
+  ).then(() => {
     res.status(201);
   });
   next();

--- a/controllers/accountCtrl.js
+++ b/controllers/accountCtrl.js
@@ -13,6 +13,7 @@ module.exports.updateAccount = (req, res, next) => {
 
 module.exports.renderAccount = (req, res, next) => {
   const { PaymentType } = req.app.get('models');
+
   PaymentType.findAll({
     where: { user_id: req.user.id },
   }).then(paymentTypes => {
@@ -43,8 +44,8 @@ module.exports.updatePaymentType = (req, res, next) => {
       provider,
       account_number: accountNumber,
       active: 't',
-    }).then(value => {
-      res.render("account", req.user);
+    }).then(() => {
+      res.redirect('/account');
     });
   }
 }
@@ -52,12 +53,13 @@ module.exports.updatePaymentType = (req, res, next) => {
 module.exports.deletePaymentType = (req, res, next) => {
   const paymentTypeId = +req.body.paymentTypeId;
   const { PaymentType } = req.app.get('models');
-  
+
   PaymentType.destroy({
     where: {
       id: paymentTypeId,
     },
   }).then(() => {
-    res.redirect('/account');
+    res.status(201);
   });
+  next();
 };

--- a/controllers/accountCtrl.js
+++ b/controllers/accountCtrl.js
@@ -1,19 +1,42 @@
 
 
-module.exports.updateAccount = (req, res, next)=>{
-  console.log('req.user',req.user);
-  req.app.get("models").User.find({where: {id: req.user.id}})
-  .then(user=>{
-    return user.updateAttributes(req.body);
-  })
-  .then(updatedUser=>{
-    res.render("account", updatedUser.dataValues);
-  })
+module.exports.updateAccount = (req, res, next) => {
+  console.log('req.user', req.user);
+  req.app.get("models").User.find({ where: { id: req.user.id } })
+    .then(user => {
+      return user.updateAttributes(req.body);
+    })
+    .then(updatedUser => {
+      res.render("account", updatedUser.dataValues);
+    })
 }
 
-module.exports.renderAccount = (req, res, next)=>{
+module.exports.renderAccount = (req, res, next) => {
   res.render("account", req.user);
 }
-module.exports.renderAccountEdit = (req, res, next)=>{
+
+module.exports.renderAccountEdit = (req, res, next) => {
   res.render("accountEdit", req.user);
+}
+
+module.exports.renderAddPaymentType = (req, res, next) => {
+  res.render("addPaymentType", req.user);
+}
+
+module.exports.updatePaymentType = (req, res, next) => {
+  const provider = req.body.provider;
+  const accountNumber = req.body.account_number;
+  const userId = req.user.id;
+  const { PaymentType } = req.app.get('models');
+
+  if(provider && accountNumber && userId){
+    PaymentType.create({
+      user_id: userId,
+      provider,
+      account_number: accountNumber,
+      active: 't',
+    }).then(value => {
+      res.render("account", req.user);
+    });
+  }
 }

--- a/routes/account.js
+++ b/routes/account.js
@@ -8,7 +8,8 @@ const {
   updateAccount,
   renderAccountEdit,
   renderAddPaymentType,
-  updatePaymentType
+  updatePaymentType,
+  deletePaymentType
  } = require('../controllers/accountCtrl');
 
 router.get("/account/edit", renderAccountEdit);
@@ -16,6 +17,9 @@ router.post("/account/edit", updateAccount);
 
 router.get("/account/addPaymentType", renderAddPaymentType);
 router.post("/account/addPaymentType", updatePaymentType);
+
+router.post("/account/deletePaymentType", deletePaymentType);
+
 
 router.get("/account", renderAccount);
 

--- a/routes/account.js
+++ b/routes/account.js
@@ -3,10 +3,19 @@
 
 const { Router } = require('express');
 const router = Router();
-const { renderAccount, updateAccount, renderAccountEdit } = require('../controllers/accountCtrl');
+const {
+  renderAccount,
+  updateAccount,
+  renderAccountEdit,
+  renderAddPaymentType,
+  updatePaymentType
+ } = require('../controllers/accountCtrl');
 
 router.get("/account/edit", renderAccountEdit);
 router.post("/account/edit", updateAccount);
+
+router.get("/account/addPaymentType", renderAddPaymentType);
+router.post("/account/addPaymentType", updatePaymentType);
 
 router.get("/account", renderAccount);
 

--- a/routes/account.js
+++ b/routes/account.js
@@ -18,8 +18,7 @@ router.post("/account/edit", updateAccount);
 router.get("/account/addPaymentType", renderAddPaymentType);
 router.post("/account/addPaymentType", updatePaymentType);
 
-router.post("/account/deletePaymentType", deletePaymentType);
-
+router.delete("/account/deletePaymentType", deletePaymentType, renderAccount);
 
 router.get("/account", renderAccount);
 

--- a/seeders/data/products.json
+++ b/seeders/data/products.json
@@ -436,7 +436,7 @@
       "title": "Awesome Rubber Chips",
       "price": "389.00",
       "product_type_id": 6,
-      "user_id": 1,
+      "user_id" : 1,
       "description": "Dolorem porro non enim pariatur delectus.",
       "listing_date": "2018/04/03",
       "quantity": 5

--- a/views/account.pug
+++ b/views/account.pug
@@ -12,5 +12,9 @@ block content
 
   button#editAccount Edit
 
+  #paymentType
+    h2 Payment Types
+    button#addPaymentType Add Payment Type
+
 block scripts
   script(src='js/account.js')

--- a/views/account.pug
+++ b/views/account.pug
@@ -14,7 +14,7 @@ block content
 
   #paymentType
     h2 Payment Types
-    ol Payment Types
+    ol
       each type, index in paymentTypes
         li(id=index)
           #paymentType

--- a/views/account.pug
+++ b/views/account.pug
@@ -14,6 +14,14 @@ block content
 
   #paymentType
     h2 Payment Types
+    ol Payment Types
+      each type, index in paymentTypes
+        li(id=index)
+          #paymentType
+            .provider= type.provider
+            .account-number= type.account_number
+            button(id=type.id).deletePaymentType Delete
+
     button#addPaymentType Add Payment Type
 
 block scripts

--- a/views/addPaymentType.pug
+++ b/views/addPaymentType.pug
@@ -1,0 +1,12 @@
+extends index.pug
+
+block content
+  h2 Add Payment Type
+  form(action='/account/addPaymentType' method='POST')
+    input(type='number' value=account_number name='account_number')
+    select(name='provider')
+      option(value='AmEx') AmEx
+      option(value='Visa') Visa
+      option(value='MasterCard') MasterCard
+      option(value='PayPal') PayPal
+    button#saveAccount(type='submit') Save


### PR DESCRIPTION
# Description
Implements adding and deleting of payment types.

## Related Ticket(s)
Completes Ticket #21  and #22 (User can add and delete payment type)

## Expected Behavior
When logged in on /account, and you select add payment type, you should be brought to a form.  After submitting pertinent info, it should show up on the page.  When you press delete, the payment type should be removed (set active to false and not visible). 

## Steps to Test Solution

1. `Login`, and navigate to `account`
1.  In Postgres, run `select * from payment_types;` on the `bangazon_site` database to see what payment_types is like before adding another payment type.
1.  On /account, `add` a `payment type`.  You should be redirected back to the account page when complete
1. Select the payment types again.  There should now be another with your entered info and active set to true.
1. On /account, select delete on a payment type.  The page should redirect and it should be gone.  Select the payment types in Postgres, and the payment type `active` should be set to `false`.

## Documentation
- [x] I have added documentation to README.md
- [ ] There is already documentation in the README.md for this feature
